### PR TITLE
Add peer deps into lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -667,6 +673,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/semver": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.0.tgz",
+      "integrity": "sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2036,6 +2047,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "crypto-browserify": {
@@ -4937,6 +4956,12 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
         }
       }
     },
@@ -5301,6 +5326,14 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -5313,6 +5346,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -6400,8 +6441,7 @@
         "estree-walker": "^0.6.1",
         "is-reference": "^1.1.2",
         "magic-string": "^0.25.2",
-        "resolve": "^1.11.0",
-        "rollup-pluginutils": "^2.8.1"
+        "resolve": "^1.11.0"
       }
     },
     "rollup-plugin-css-only": {
@@ -6430,6 +6470,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       }
@@ -6539,10 +6580,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
     },
     "serialize-javascript": {
       "version": "2.1.2",
@@ -7325,6 +7365,12 @@
         "yargs-parser": "10.x"
       },
       "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "yargs-parser": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "webpack-cli": "^3.3.10"
   },
   "dependencies": {
+    "@types/semver": "^6.2.0",
     "emotion": "^10.0.23",
     "immutable": "^4.0.0-rc.12",
     "monaco-editor": "^0.19.0",
@@ -32,6 +33,7 @@
     "react-dom": "16.12.0",
     "react-icons": "^3.8.0",
     "rollup-plugin-commonjs-fork": "git+https://git@github.com/esymode/rollup-plugin-commonjs-fork.git",
+    "semver": "^7.1.1",
     "ts-binary-types": "^0.8.0",
     "ts-union": "^2.1.1"
   },

--- a/src/packaging/doResolution.ts
+++ b/src/packaging/doResolution.ts
@@ -30,7 +30,7 @@ export const doPackageResolution = async (
 
   let res = lockFromExplicitDeps(input);
 
-  while (res.stage !== "done") {
+  while (res.stage !== "done-success" && res.stage !== "done-error") {
     const results = allResult(
       await Promise.all(
         res.resolveSemverRequests.map(
@@ -68,7 +68,11 @@ export const doPackageResolution = async (
     res = lockFromExplicitDeps(forResume);
   }
 
-  return Ok(res.lock);
+  if (res.stage === "done-success") {
+    return Ok(res.lock);
+  } else {
+    return Err(res.err);
+  }
 };
 
 const findMatchingVersionForSemverRange = async (

--- a/src/packaging/packageResolution.test.ts
+++ b/src/packaging/packageResolution.test.ts
@@ -45,7 +45,7 @@ test("resolves single leaf package", () => {
     ],
     state: res2.state
   });
-  if (res3.stage !== "done") {
+  if (res3.stage !== "done-success") {
     throw new Error("wrong stage");
   }
   expect(res3.lock).toStrictEqual({
@@ -295,7 +295,7 @@ test("it dedups requests to resolve the same package.json", () => {
     ],
     state: res5.state
   });
-  if (res6.stage !== "done") {
+  if (res6.stage !== "done-success") {
     throw new Error("wrong stage");
   }
   expect(res6.lock).toEqual({
@@ -388,7 +388,7 @@ test("resolve diamond of packages", () => {
     state: res4.state
   });
 
-  if (res5.stage !== "done") {
+  if (res5.stage !== "done-success") {
     throw new Error("wrong stage");
   }
 
@@ -396,5 +396,97 @@ test("resolve diamond of packages", () => {
     "a@^1.2.3": "1.2.3",
     "b@^1.2.3": "1.2.3",
     "c@^1.2.3": "1.2.3"
+  });
+});
+
+test("resolves peer dependencies but does not fetch them", () => {
+  const input: StartOfResolution = {
+    stage: "start",
+    deps: {
+      a: "1.0.0",
+      b: "1.0.0"
+    }
+  };
+
+  const res = lockFromExplicitDeps(input);
+  if (res.stage !== "paused-for-io") {
+    throw new Error("wrong stage");
+  }
+
+  expect(res.resolveSemverRequests).toStrictEqual([
+    { name: "a", semver: "1.0.0" },
+    { name: "b", semver: "1.0.0" }
+  ]);
+  expect(res.fetchPackageJsonRequests).toStrictEqual([]);
+
+  const res2 = lockFromExplicitDeps({
+    stage: "ready-to-resume",
+    resolvedSemVerRequests: [
+      [{ name: "a", semver: "1.0.0" }, "1.0.0"],
+      [{ name: "b", semver: "1.0.0" }, "1.0.0"]
+    ],
+    fetchedPackageJsonRequests: [],
+    state: res.state
+  });
+  if (res2.stage !== "paused-for-io") {
+    throw new Error("wrong stage");
+  }
+
+  expect(res2.fetchPackageJsonRequests).toStrictEqual([
+    { name: "a", version: "1.0.0" },
+    { name: "b", version: "1.0.0" }
+  ]);
+  expect(res2.resolveSemverRequests).toStrictEqual([]);
+
+  const res3 = lockFromExplicitDeps({
+    stage: "ready-to-resume",
+    resolvedSemVerRequests: [],
+    fetchedPackageJsonRequests: [
+      [{ name: "a", version: "1.0.0" }, { dependencies: { c: "1.0.0" } }],
+      [{ name: "b", version: "1.0.0" }, { peerDependencies: { c: "^1.0.0" } }]
+    ],
+    state: res2.state
+  });
+  if (res3.stage !== "paused-for-io") {
+    throw new Error("wrong stage");
+  }
+  expect(res3.resolveSemverRequests).toStrictEqual([
+    { name: "c", semver: "1.0.0" }
+  ]);
+  expect(res3.fetchPackageJsonRequests).toStrictEqual([]);
+
+  const res4 = lockFromExplicitDeps({
+    stage: "ready-to-resume",
+    resolvedSemVerRequests: [[{ name: "c", semver: "1.0.0" }, "1.0.0"]],
+    fetchedPackageJsonRequests: [],
+    state: res3.state
+  });
+  if (res4.stage !== "paused-for-io") {
+    throw new Error("wrong stage");
+  }
+
+  expect(res4.fetchPackageJsonRequests).toStrictEqual([
+    { name: "c", version: "1.0.0" }
+  ]);
+  expect(res4.resolveSemverRequests).toStrictEqual([]);
+
+  const res5 = lockFromExplicitDeps({
+    stage: "ready-to-resume",
+    resolvedSemVerRequests: [],
+    fetchedPackageJsonRequests: [
+      [{ name: "c", version: "1.0.0" }, { dependencies: {} }]
+    ],
+    state: res4.state
+  });
+
+  if (res5.stage !== "done-success") {
+    throw new Error("wrong stage");
+  }
+
+  expect(res5.lock).toStrictEqual({
+    "a@1.0.0": "1.0.0",
+    "b@1.0.0": "1.0.0",
+    "c@1.0.0": "1.0.0",
+    "c@^1.0.0": "1.0.0"
   });
 });

--- a/src/semver.d.ts
+++ b/src/semver.d.ts
@@ -1,0 +1,4 @@
+declare module "semver/ranges/max-satisfying" {
+  const maxSatisfying: typeof import("semver").maxSatisfying;
+  export = maxSatisfying;
+}


### PR DESCRIPTION
This is required for handling packages with peer dependencies (like `react-dom`) - we need to be able to look up a specific version based on the peer dependency semver range, but we should try and select from the versions resolved by regular dependency semver ranges.

An alternative would be to do this calculation at bundling time, but putting these mappings in the lockfile seemed better.